### PR TITLE
leaving events

### DIFF
--- a/levelupapi/fixtures/events.json
+++ b/levelupapi/fixtures/events.json
@@ -34,7 +34,7 @@
             "time": "3:00 PM",
             "description": "Friday night Settlers and drinks",
             "title": "Vale of the Frost King",
-            "attendees": [1]
+            "attendees": [1, 2]
         }
     }
 ]

--- a/levelupapi/models/event.py
+++ b/levelupapi/models/event.py
@@ -20,6 +20,16 @@ class Event(models.Model):
     title = models.CharField(max_length=100)
     attendees = models.ManyToManyField("Gamer", through="EventGamer", related_name="attending")
 
+    @property
+    def joined(self):
+        """Add the following custom property to event class.
+        """
+        return self.__joined
+
+    @joined.setter
+    def joined(self, value):
+        self.__joined = value
+
     def __str__(self) -> str:
         return f'{self.game.name} on {self.date} hosted by {self.host}'
     

--- a/levelupapi/views/event.py
+++ b/levelupapi/views/event.py
@@ -92,12 +92,19 @@ class EventView(ViewSet):
         Returns:
             Response -- JSON serialized list of events ojb to json
         """
+        # Get the current authenticated user
+        gamer = Gamer.objects.get(user=request.auth.user)
         events = Event.objects.all()
 
+        # Set the `joined` property on every event
+        for event in events:
+            # Check to see if the gamer is in the attendees list on the event
+            event.joined = gamer in event.attendees.all()
+
         # Support filtering events by game
-        game = self.request.query_params.get('game', None)
+        game = self.request.query_params.get('gameId', None)
         if game is not None:
-            events = events.filter(game__id=game)
+            events = events.filter(game__id=type)
 
         serializer = EventSerializer(
             events, many=True, context={'request': request})
@@ -167,4 +174,5 @@ class EventSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Event
-        fields = ('id', 'title', 'date', 'time', 'description', 'host', 'game')
+        fields = ('id', 'title', 'date', 'time', 'description', 'host', 'game', 'attendees',
+          'joined')


### PR DESCRIPTION
The issue: adding the ability to leave events on the server side

Reason for the new commit: we need to allow the users the ability to leave or indicate that they aren't going to a posted event .
Solution: added what will allow gamers to easily join and leave scheduled events. Added the value of the joined property on each event. updated the @joined in the Models event.py to indicate whether a user has joined the event or not. 
also added a joined field to indicated on the Views event.py so show if the user has selected that they have joined of left the event.

Added notes throughout
Tested and ensured it was working correctly on all browsers